### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ oblurlay
 ==================
 Implement a blur view of iOS style with css,svg and jquery
 
-##Example
+## Example
 http://git.blivesta.com/oblurlay
 
-##Setup
+## Setup
 ~~~ go
 <link rel="stylesheet" href="dist/css/oblurlay.min.css">
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
@@ -33,9 +33,9 @@ $(document).ready(function() {
 
 ~~~
 
-##Browsers
+## Browsers
 - chrome
 - safari
 
-##License
+## License
 Released under the MIT license.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
